### PR TITLE
enable blank line between lists in WikiCreole

### DIFF
--- a/modules/creole.pl
+++ b/modules/creole.pl
@@ -470,8 +470,8 @@ sub CreoleListAndNewLineRule {
   # # numbered list
   # * bullet list (nestable; needs space when nested to disambiguate from bold)
   if (($bol             and m/\G[ \t]*([#*])[ \t]*/cg) or
-      ($is_in_list_item and m/\G[ \t]*\n+[ \t]*(#+)[ \t]*/cg) or
-      ($is_in_list_item and m/\G[ \t]*\n+[ \t]*(\*+)[ \t]+/cg)) {
+      ($is_in_list_item and m/\G[ \t]*\n[ \t]*(#+)[ \t]*/cg) or
+      ($is_in_list_item and m/\G[ \t]*\n[ \t]*(\*+)[ \t]+/cg)) {
     # Note: the first line of this return statement is --not-- equivalent to:
     # "return CloseHtmlEnvironmentUntil('li')", as that line does not permit
     # modules overriding the CloseHtmlEnvironments() function to "have a say."
@@ -482,7 +482,7 @@ sub CreoleListAndNewLineRule {
   # - bullet list (not nestable; always needs space)
   elsif ($CreoleDashStyleUnorderedLists and (
         ($bol and             m/\G[ \t]*(-)[ \t]+/cg) or
-        ($is_in_list_item and m/\G[ \t]*\n+[ \t]*(-)[ \t]+/cg))) {
+        ($is_in_list_item and m/\G[ \t]*\n[ \t]*(-)[ \t]+/cg))) {
     return ($is_in_list_item ? CloseHtmlEnvironmentUntil('li') : CloseHtmlEnvironments())
       .OpenHtmlEnvironment('ul', length($1))
       .AddHtmlEnvironment ('li');


### PR DESCRIPTION
With this fix, blank line between lists in WikiCreole is no longer ignored.
The blank line appears as a space between lists.
This is useful in order to group lists without comments.
